### PR TITLE
Second attempt at Unicode fix

### DIFF
--- a/hapi/contacts.py
+++ b/hapi/contacts.py
@@ -1,5 +1,6 @@
 from base import BaseClient
 import logging_helper
+from urllib import quote
 
 
 CONTACTS_API_VERSION = '1'
@@ -16,17 +17,19 @@ class ContactsClient(BaseClient):
         self.log = logging_helper.get_log('hapi.contacts')
 
     def _get_path(self, subpath):
-        return u'contacts/v%s/%s' % (self.options.get('version') or CONTACTS_API_VERSION, subpath)
+        return 'contacts/v%s/%s' % (self.options.get('version') or CONTACTS_API_VERSION, subpath)
 
     def create_or_update_a_contact(self, email, data=None, **options):
         """ Creates or Updates a client with the supplied data. """
         data = data or {}
-        return self._call(u'contact/createOrUpdate/email/{email}'.format(email=email),
+        return self._call('contact/createOrUpdate/email/{email}'.
+                          format(email=quote(email.encode('utf-8'))),
                           data=data, method='POST', **options)
 
     def get_contact_by_email(self, email, **options):
         """ Gets contact specified by email address. """
-        return self._call(u'contact/email/{email}/profile'.format(email=email),
+        return self._call('contact/email/{email}/profile'.
+                          format(email=quote(email.encode('utf-8'))),
                           method='GET', **options)
 
     def update_a_contact(self, contact_id, data=None, **options):
@@ -37,4 +40,5 @@ class ContactsClient(BaseClient):
 
     def delete_a_contact(self, contact_id, **options):
         """ Deletes a contact by contact_id. """
-        return self._call('contact/vid/{contact_id}'.format(contact_id=contact_id), method='DELETE', **options)
+        return self._call('contact/vid/{contact_id}'.
+                          format(contact_id=contact_id), method='DELETE', **options)

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='hapipy',
-    version='2.10.5.2',
+    version='2.10.5.3',
     description="A python wrapper around HubSpot's APIs",
     long_description=open('README.md').read(),
     author='HubSpot Dev Team',


### PR DESCRIPTION
This works rather better -- we now encode the email address before quoting it to go into the URL.